### PR TITLE
Add ‘volume_stable’ invariant measure to improve numerical stability in NormalizedMI

### DIFF
--- a/src/normi/__init__.py
+++ b/src/normi/__init__.py
@@ -4,7 +4,7 @@
 __all__ = ['NormalizedMI']
 
 NORMS = {'joint', 'geometric', 'arithmetic', 'min', 'max'}
-INVMEASURES = {'radius', 'volume', 'kraskov'}
+INVMEASURES = {'radius', 'volume', 'volume_stable', 'kraskov'}
 
 from ._estimators import NormalizedMI
 

--- a/tests/test__estimators.py
+++ b/tests/test__estimators.py
@@ -40,6 +40,13 @@ def X1_result(method, measure):
             'arithmetic': 0.6268627,
             'geometric': 0.6269047,
         },
+        'volume_stable': {
+            'joint': 0.4565186,
+            'max': 0.6196869,
+            'min': 0.6342067,
+            'arithmetic': 0.6268627,
+            'geometric': 0.6269047,
+        },
     }[measure][method]
 
 
@@ -51,6 +58,14 @@ def X1_result(method, measure):
         ('volume', 1, np.arange(5), np.arange(5) / 2, None),
         (
             'volume',
+            2,
+            np.arange(5),
+            [0, 0.40824829, 0.81649658, 1.22474487, 1.63299316],
+            None,
+        ),
+        ('volume_stable', 1, np.arange(5), np.arange(5) / 2, None),
+        (
+            'volume_stable',
             2,
             np.arange(5),
             [0, 0.40824829, 0.81649658, 1.22474487, 1.63299316],
@@ -188,6 +203,34 @@ def test__reset(normalize_method, X, kwargs):
                 'invariant_measure': 'volume',
             },
             X1_result('geometric', 'volume'),
+            None,
+        ),
+        (
+            X1(),
+            {'normalize_method': 'arithmetic', 'invariant_measure': 'volume_stable'},
+            X1_result('arithmetic', 'volume_stable'),
+            None,
+        ),
+        (
+            X1(),
+            {'normalize_method': 'geometric', 'invariant_measure': 'volume_stable'},
+            X1_result('geometric', 'volume_stable'),
+            None,
+        ),
+        (
+            X1(),
+            {'normalize_method': 'joint', 'invariant_measure': 'volume_stable'},
+            X1_result('joint', 'volume_stable'),
+            None,
+        ),
+        (
+            X1(),
+            {
+                'n_dims': np.array([1, 1]),
+                'normalize_method': 'geometric',
+                'invariant_measure': 'volume_stable',
+            },
+            X1_result('geometric', 'volume_stable'),
             None,
         ),
     ],


### PR DESCRIPTION
This pull request introduces a new volume_stable invariant measure to the NormalizedMI estimator to enhance the numerical stability of mean k-NN volume calculations, particularly in high-dimensional spaces. The new measure is based on a logarithmic transformation technique that mitigates numerical overflow, as described in the manuscript “[Improving Numerical Stability of Normalized Mutual Information Estimator on High Dimensions](https://arxiv.org/abs/2410.07642).”

Changes include:

* Implementation of the volume_stable invariant measure, providing a more stable calculation of the mean k-NN volume.
* Updates to the _scale_nearest_neighbor_distance function and INVMEASURES to support the new invariant measure.
* Expansion of unit tests to cover the volume_stable option, ensuring correctness across various metrics.

This addition improves the stability of normalized mutual information estimation, particularly in high-dimensional settings where standard volume normalization may lead to numerical instability (overflow).